### PR TITLE
Support wider range of PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
 language: php
 
 php:
-  - '5.6'
-  - '7.0'
-  - nightly
+    - 5.4
+    - 5.5
+    - 5.6
+    - 7.0
+    - hhvm
+
+matrix:
+    fast_finish: true
+    include:
+        - php: 5.4
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
 
 before_script:
   - composer install
+
 
 script:
   - find src spec -name "*.php" -print0 | xargs -0 -n1 -P8 php -l

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.1] - 2016-08-12
+### Changed
+
+- Links on Readme to point to right location
+- Now support PHP 5.4 to PHP 7.1
+
 ## [0.1.0] - 2016-08-12
 ### Added
 
 - Everything, initial release
 
+[0.1.0]: https://github.com/fitbug/symfony-yaml-serializer-encoder-decoder/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/fitbug/symfony-yaml-serializer-encoder-decoder/releases/tag/v0.1.0

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     }
   ],
   "require": {
-    "symfony/serializer": "^3.0.0",
-    "symfony/yaml": "^3.1"
+    "symfony/serializer": "^v2.0.0 || ^3.0.0",
+    "symfony/yaml": "^v2.0.0 || ^3.0.0"
   },
   "autoload": {
     "psr-4": {
@@ -25,7 +25,7 @@
     }
   },
   "require-dev": {
-    "phpspec/phpspec": "^3.0",
+    "phpspec/phpspec": "^2.0.0 || ^3.0.0",
     "squizlabs/php_codesniffer": "^2.6"
   }
 }

--- a/spec/YamlDecodeSpec.php
+++ b/spec/YamlDecodeSpec.php
@@ -2,21 +2,19 @@
 
 namespace spec\Fitbug\SymfonySerializer\YamlEncoderDecoder;
 
-use Fitbug\SymfonySerializer\YamlEncoderDecoder\YamlDecode;
 use PhpSpec\ObjectBehavior;
-use Symfony\Component\Serializer\Encoder\DecoderInterface;
 
 class YamlDecodeSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType(YamlDecode::class);
+        $this->shouldHaveType('Fitbug\SymfonySerializer\YamlEncoderDecoder\YamlDecode');
 
     }
 
     function it_is_a_decoder()
     {
-        $this->shouldImplement(DecoderInterface::class);
+        $this->shouldImplement('Symfony\Component\Serializer\Encoder\DecoderInterface');
     }
 
     function it_supports_type_yaml()

--- a/spec/YamlEncodeSpec.php
+++ b/spec/YamlEncodeSpec.php
@@ -2,21 +2,19 @@
 
 namespace spec\Fitbug\SymfonySerializer\YamlEncoderDecoder;
 
-use Fitbug\SymfonySerializer\YamlEncoderDecoder\YamlEncode;
 use PhpSpec\ObjectBehavior;
-use Symfony\Component\Serializer\Encoder\EncoderInterface;
 
 class YamlEncodeSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType(YamlEncode::class);
+        $this->shouldHaveType('Fitbug\SymfonySerializer\YamlEncoderDecoder\YamlEncode');
 
     }
 
-    function it_is_a_decoder()
+    function it_is_a_encoder()
     {
-        $this->shouldImplement(EncoderInterface::class);
+        $this->shouldImplement('Symfony\Component\Serializer\Encoder\EncoderInterface');
     }
 
     function it_supports_type_yaml()
@@ -29,7 +27,7 @@ class YamlEncodeSpec extends ObjectBehavior
         $this->supportsEncoding('json')->shouldReturn(false);
     }
 
-    function it_decodes_yaml()
+    function it_encodes_yaml()
     {
         $basicYaml
             = <<<YAML
@@ -40,7 +38,7 @@ YAML;
         $this->encode(['example' => 'yaml'], 'yaml')->shouldReturn($basicYaml);
     }
 
-    function it_decodes_passes_options_in_constructor_to_parser()
+    function it_encodes_using_passes_options_in_constructor_to_parser()
     {
         $basicYaml
             = <<<YAML

--- a/spec/YamlEncoderSpec.php
+++ b/spec/YamlEncoderSpec.php
@@ -4,14 +4,25 @@ namespace spec\Fitbug\SymfonySerializer\YamlEncoderDecoder;
 
 use Fitbug\SymfonySerializer\YamlEncoderDecoder\YamlDecode;
 use Fitbug\SymfonySerializer\YamlEncoderDecoder\YamlEncode;
-use Fitbug\SymfonySerializer\YamlEncoderDecoder\YamlEncoder;
 use PhpSpec\ObjectBehavior;
 
 class YamlEncoderSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType(YamlEncoder::class);
+        $this->shouldHaveType('Fitbug\SymfonySerializer\YamlEncoderDecoder\YamlEncoder');
+    }
+
+
+    function it_is_a_decoder()
+    {
+        $this->shouldImplement('Symfony\Component\Serializer\Encoder\DecoderInterface');
+    }
+
+
+    function it_is_a_encoder()
+    {
+        $this->shouldImplement('Symfony\Component\Serializer\Encoder\EncoderInterface');
     }
 
     function it_proxies_the_supports_decoding_method(YamlDecode $yamlDecode)

--- a/src/YamlDecode.php
+++ b/src/YamlDecode.php
@@ -67,9 +67,21 @@ class YamlDecode implements DecoderInterface
     public function decode($data, $format, array $context = [])
     {
         $context = $this->resolveContext($context);
-        $options = $this->contextToOptions($context);
 
-        return Yaml::parse($data, $options);
+        if ($this->isYamlOldStyleInterface()) {
+            $results = Yaml::parse(
+                $data,
+                $context[ self::OPTION_EXCEPTION_ON_INVALID_TYPE ],
+                $context[ self::OPTION_OBJECT ],
+                $context[ self::OPTION_OBJECT_FOR_MAP ]
+            );
+        } else {
+            $options = $this->contextToOptions($context);
+
+            $results = Yaml::parse($data, $options);
+        }
+
+        return $results;
     }
 
     /**
@@ -130,5 +142,10 @@ class YamlDecode implements DecoderInterface
         }
 
         return $bitMaskedOption;
+    }
+
+    private function isYamlOldStyleInterface()
+    {
+        return !defined("Symfony\\Component\\Yaml\\Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE");
     }
 }

--- a/src/YamlEncode.php
+++ b/src/YamlEncode.php
@@ -88,14 +88,26 @@ class YamlEncode implements EncoderInterface
     public function encode($data, $format, array $context = [])
     {
         $context = $this->resolveContext($context);
-        $options = $this->contextToOptions($context);
 
-        $encodedData = Yaml::dump(
-            $data,
-            $context[ self::OPTION_INLINE ],
-            $context[ self::OPTION_INDENT ],
-            $options
-        );
+        if ($this->isYamlOldStyleInterface()) {
+            $encodedData = Yaml::dump(
+                $data,
+                $context[ self::OPTION_INLINE ],
+                $context[ self::OPTION_INDENT ],
+                $context[ self::OPTION_EXCEPTION_ON_INVALID_TYPE ],
+                $context[ self::OPTION_OBJECT ]
+            );
+
+        } else {
+            $options = $this->contextToOptions($context);
+
+            $encodedData = Yaml::dump(
+                $data,
+                $context[ self::OPTION_INLINE ],
+                $context[ self::OPTION_INDENT ],
+                $options
+            );
+        }
 
         return $encodedData;
     }
@@ -161,5 +173,10 @@ class YamlEncode implements EncoderInterface
     public function supportsEncoding($format)
     {
         return $format == self::SUPPORTED_ENCODING_YAML;
+    }
+
+    private function isYamlOldStyleInterface()
+    {
+        return !defined("Symfony\\Component\\Yaml\\Yaml::DUMP_OBJECT");
     }
 }


### PR DESCRIPTION
This will ensure that we can support all the same versions of PHP that
are supported by jolicode/jane-openapi which this is being used in.
